### PR TITLE
Handling :init.stop gracefully and other misc changes

### DIFF
--- a/c_src/exile.c
+++ b/c_src/exile.c
@@ -56,7 +56,7 @@ static const int PIPE_CLOSED = -1;
 static const int CMD_EXIT = -1;
 static const int MAX_ARGUMENTS = 50;
 static const int MAX_ARGUMENT_LEN = 1024;
-static const int MAX_ENV_LEN = 1024;
+static const int MAX_ENV_VAR_LEN = 1024;
 static const int UNBUFFERED_READ = -1;
 static const int PIPE_BUF_SIZE = 65535;
 
@@ -314,8 +314,8 @@ static ERL_NIF_TERM execute(ErlNifEnv *env, int argc,
     return enif_make_badarg(env);
   }
 
-  char _args_temp[MAX_ARGUMENTS][MAX_ARGUMENT_LEN + 1];
-  char *exec_args[MAX_ARGUMENTS + 1];
+  char _args_temp[args_len][MAX_ARGUMENT_LEN + 1];
+  char *exec_args[args_len + 1];
 
   list = argv[0];
   for (unsigned int i = 0; i < args_len; i++) {
@@ -335,12 +335,9 @@ static ERL_NIF_TERM execute(ErlNifEnv *env, int argc,
     return enif_make_badarg(env);
   }
 
-  if (args_len > MAX_ARGUMENTS) {
-    error("env size exceeds limit: %d", MAX_ARGUMENTS);
-    return enif_make_badarg(env);
-  }
+  debug("env size: %d", env_len);
 
-  char _env_temp[env_len][MAX_ENV_LEN];
+  char _env_temp[env_len][MAX_ENV_VAR_LEN];
   char *exec_env[env_len + 1];
 
   list = argv[1];
@@ -348,7 +345,7 @@ static ERL_NIF_TERM execute(ErlNifEnv *env, int argc,
     if (enif_get_list_cell(env, list, &head, &tail) != true)
       return enif_make_badarg(env);
 
-    if (enif_get_string(env, head, _env_temp[i], MAX_ENV_LEN, ERL_NIF_LATIN1) <
+    if (enif_get_string(env, head, _env_temp[i], MAX_ENV_VAR_LEN, ERL_NIF_LATIN1) <
         1)
       return enif_make_badarg(env);
     exec_env[i] = _env_temp[i];

--- a/lib/exile.ex
+++ b/lib/exile.ex
@@ -3,6 +3,20 @@ defmodule Exile do
   Exile is an alternative for beam ports with back-pressure and non-blocking IO
   """
 
+  use Application
+
+  @doc false
+  def start(_type, _args) do
+    opts = [
+      name: Exile.WatcherSupervisor,
+      strategy: :one_for_one
+    ]
+
+    # we use DynamicSupervisor for cleaning up external processes on
+    # :init.stop or SIGTERM
+    DynamicSupervisor.start_link(opts)
+  end
+
   @doc """
   Runs the given command with arguments and return an Enumerable to read command output.
 

--- a/lib/exile.ex
+++ b/lib/exile.ex
@@ -40,7 +40,7 @@ defmodule Exile do
                            ```
                            By defaults no input will be given to the command
     * `exit_timeout`     - Duration to wait for external program to exit after completion before raising an error. Defaults to `:infinity`
-    * `chunk_size`       - Size of each iodata chunk emitted by Enumerable stream. When set to `nil` the output is unbuffered and chunk size will be variable. Defaults to 65535
+    * `chunk_size`       - Size of each iodata chunk emitted by Enumerable stream. When set to `:unbuffered` the output is unbuffered and chunk size will be variable depending on the amount of data availble at that time. Defaults to 65535
   All other options are passed to `Exile.Process.start_link/3`
 
   ### Examples

--- a/lib/exile/process.ex
+++ b/lib/exile/process.ex
@@ -335,9 +335,16 @@ defmodule Exile.Process do
   defp stream_type(:stdout), do: 1
 
   defp normalize_env(env) do
-    Enum.map(env, fn {key, value} ->
-      (String.trim(key) <> "=" <> String.trim(value))
-      |> to_charlist()
+    user_env =
+      Map.new(env, fn {key, value} ->
+        {String.trim(key), String.trim(value)}
+      end)
+
+    # spawned process env will be beam env at that time + user env.
+    # this is similar to erlang behavior
+    Map.merge(System.get_env(), user_env)
+    |> Enum.map(fn {k, v} ->
+      to_charlist(k <> "=" <> v)
     end)
   end
 end

--- a/lib/exile/process_nif.ex
+++ b/lib/exile/process_nif.ex
@@ -1,6 +1,5 @@
 defmodule Exile.ProcessNif do
   @moduledoc false
-
   @on_load :load_nifs
 
   def load_nifs do

--- a/lib/exile/process_nif.ex
+++ b/lib/exile/process_nif.ex
@@ -25,4 +25,13 @@ defmodule Exile.ProcessNif do
   def os_pid(_context), do: :erlang.nif_error(:nif_library_not_loaded)
 
   def alive?(_context), do: :erlang.nif_error(:nif_library_not_loaded)
+
+  # non-nif helper functions
+  defmacro fork_exec_failure(), do: 125
+
+  defmacro nif_false(), do: 0
+  defmacro nif_true(), do: 1
+
+  def to_process_fd(:stdin), do: 0
+  def to_process_fd(:stdout), do: 1
 end

--- a/lib/exile/watcher.ex
+++ b/lib/exile/watcher.ex
@@ -45,8 +45,8 @@ defmodule Exile.Watcher do
       Logger.debug(fn -> "Stopping external program" end)
 
       # sys_close is idempotent, calling it multiple times is okay
-      ProcessNif.sys_close(context, stream_type(:stdin))
-      ProcessNif.sys_close(context, stream_type(:stdout))
+      ProcessNif.sys_close(context, ProcessNif.to_process_fd(:stdin))
+      ProcessNif.sys_close(context, ProcessNif.to_process_fd(:stdout))
 
       # at max we wait for 100ms for program to exit
       process_exit?(context, 100) && throw(:done)
@@ -78,7 +78,4 @@ defmodule Exile.Watcher do
       process_exit?(context)
     end
   end
-
-  defp stream_type(:stdin), do: 0
-  defp stream_type(:stdout), do: 1
 end

--- a/lib/exile/watcher.ex
+++ b/lib/exile/watcher.ex
@@ -1,0 +1,84 @@
+defmodule Exile.Watcher do
+  use GenServer, restart: :temporary
+  require Logger
+  alias Exile.ProcessNif
+
+  def start_link(args) do
+    {:ok, _pid} = GenServer.start_link(__MODULE__, args)
+  end
+
+  def watch(pid, context) do
+    spec = {Exile.Watcher, %{pid: pid, context: context}}
+    DynamicSupervisor.start_child(Exile.WatcherSupervisor, spec)
+  end
+
+  def init(args) do
+    %{pid: pid, context: context} = args
+    Process.flag(:trap_exit, true)
+    ref = Elixir.Process.monitor(pid)
+    {:ok, %{pid: pid, context: context, ref: ref}}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, _reason}, %{pid: pid, context: context, ref: ref}) do
+    attempt_graceful_exit(context)
+    {:stop, :normal, nil}
+  end
+
+  def handle_info({:EXIT, _, reason}, nil), do: {:stop, reason, nil}
+
+  # when watcher is attempted to be killed, we forcefully kill external os process.
+  # This can happen when beam receive SIGTERM
+  def handle_info({:EXIT, _, reason}, %{pid: pid, context: context}) do
+    Logger.debug(fn -> "Watcher exiting. reason: #{inspect(reason)}" end)
+    Exile.Process.stop(pid)
+    attempt_graceful_exit(context)
+    {:stop, reason, nil}
+  end
+
+  # for proper process exit parent of the child *must* wait() for
+  # child processes termination exit and "pickup" after the exit
+  # (receive child exit_status). Resources acquired by child such as
+  # file descriptors won't be released even if the child process
+  # itself is terminated.
+  defp attempt_graceful_exit(context) do
+    try do
+      Logger.debug(fn -> "Stopping external program" end)
+
+      # sys_close is idempotent, calling it multiple times is okay
+      ProcessNif.sys_close(context, stream_type(:stdin))
+      ProcessNif.sys_close(context, stream_type(:stdout))
+
+      # at max we wait for 100ms for program to exit
+      process_exit?(context, 100) && throw(:done)
+
+      Logger.debug("Failed to stop external program gracefully. attempting SIGTERM")
+      ProcessNif.sys_terminate(context)
+      process_exit?(context, 100) && throw(:done)
+
+      Logger.debug("Failed to stop external program with SIGTERM. attempting SIGKILL")
+      ProcessNif.sys_kill(context)
+      process_exit?(context, 1000) && throw(:done)
+
+      Logger.error("[exile] failed to kill external process")
+      raise "Failed to kill external process"
+    catch
+      :done -> Logger.debug(fn -> "External program exited successfully" end)
+    end
+  end
+
+  defp process_exit?(context) do
+    match?({:ok, _}, ProcessNif.sys_wait(context))
+  end
+
+  defp process_exit?(context, timeout) do
+    if process_exit?(context) do
+      true
+    else
+      :timer.sleep(timeout)
+      process_exit?(context)
+    end
+  end
+
+  defp stream_type(:stdin), do: 0
+  defp stream_type(:stdout), do: 1
+end

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Exile.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {Exile, []},
       extra_applications: [:logger]
     ]
   end

--- a/test/exile/process_test.exs
+++ b/test/exile/process_test.exs
@@ -47,7 +47,7 @@ defmodule Exile.ProcessTest do
 
     assert :ok == Process.close_stdin(s)
     add_event(logger, :input_close)
-    assert {:ok, {:exit, 0}} == Process.await_exit(s, 50)
+    assert {:ok, {:exit, 0}} == Process.await_exit(s, 100)
     Process.stop(s)
 
     assert [

--- a/test/exile/process_test.exs
+++ b/test/exile/process_test.exs
@@ -224,6 +224,11 @@ defmodule Exile.ProcessTest do
     assert {:error, _} = Process.start_link(~w(sh -c pwd), cd: "invalid")
   end
 
+  test "invalid opt" do
+    assert {:error, "invalid opts: [invalid: :test]"} =
+             Process.start_link(~w(cat), invalid: :test)
+  end
+
   test "env" do
     assert {:ok, s} = Process.start_link(~w(printenv TEST_ENV), env: %{"TEST_ENV" => "test"})
 

--- a/test/exile/process_test.exs
+++ b/test/exile/process_test.exs
@@ -8,6 +8,7 @@ defmodule Exile.ProcessTest do
     assert IO.iodata_to_binary(iodata) == "test\n"
     assert :ok == Process.close_stdin(s)
     assert {:ok, {:exit, 0}} == Process.await_exit(s, 500)
+    Process.stop(s)
   end
 
   test "write" do
@@ -23,6 +24,7 @@ defmodule Exile.ProcessTest do
     assert :ok == Process.close_stdin(s)
     assert {:eof, []} == Process.read(s)
     assert {:ok, {:exit, 0}} == Process.await_exit(s, 100)
+    Process.stop(s)
   end
 
   test "stdin close" do
@@ -46,6 +48,7 @@ defmodule Exile.ProcessTest do
     assert :ok == Process.close_stdin(s)
     add_event(logger, :input_close)
     assert {:ok, {:exit, 0}} == Process.await_exit(s, 50)
+    Process.stop(s)
 
     assert [
              {:write, "hello"},
@@ -86,6 +89,7 @@ defmodule Exile.ProcessTest do
   test "exit status" do
     {:ok, s} = Process.start_link(~w(sh -c "exit 2"))
     assert {:ok, {:exit, 2}} == Process.await_exit(s, 500)
+    Process.stop(s)
   end
 
   test "writing binary larger than pipe buffer size" do
@@ -105,6 +109,7 @@ defmodule Exile.ProcessTest do
 
     assert IO.iodata_length(iodata) == 5 * 65535
     assert {:ok, {:exit, 0}} == Process.await_exit(s, 500)
+    Process.stop(s)
   end
 
   test "back-pressure" do
@@ -141,6 +146,7 @@ defmodule Exile.ProcessTest do
     Task.await(reader)
 
     assert {:ok, {:exit, 0}} == Process.await_exit(s, 500)
+    Process.stop(s)
 
     assert [
              write: 1,
@@ -211,6 +217,7 @@ defmodule Exile.ProcessTest do
     {:ok, dir} = Process.read(s)
     assert String.trim(dir) == parent
     assert {:ok, {:exit, 0}} = Process.await_exit(s)
+    Process.stop(s)
   end
 
   test "invalid path" do

--- a/test/scripts/env.sh
+++ b/test/scripts/env.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-printf ${TEST_ENV}


### PR DESCRIPTION
* handle `:init.stop` gracefully by attempting to terminate all running external programs
* inherit env from beam process
* validate params and return proper errors

and other minor changes