### PR TITLE
support stderr stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ calling_from_make:
 
 UNAME := $(shell uname)
 
-CFLAGS ?= -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2
+CFLAGS ?= -D_POSIX_C_SOURCE=200809L -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2
 
 ifeq ($(UNAME), Darwin)
 	TARGET_CFLAGS ?= -fPIC -undefined dynamic_lookup -dynamiclib -Wextra

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Exile.stream!(~w(ffmpeg -i pipe:0 -f mp3 pipe:1), input: File.stream!("music_vid
 |> Stream.run()
 ```
 
-`Exile.stream!` is a convenience wrapper around `Exile.Process`. Prefer using `Exile.stream!` over using `Exile.Process` directly.
+`Exile.stream!/2` is a convenience wrapper around `Exile.Process`. Prefer using `Exile.stream!` over using `Exile.Process` directly.
 
 Exile requires OTP v22.1 and above.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Exile.stream!(~w(ffmpeg -i pipe:0 -f mp3 pipe:1), input: File.stream!("music_vid
 |> Stream.run()
 ```
 
-`Exile.stream!` is a convenience wrapper around `Exile.Process`. If you want more control over stdin, stdout, and os process use `Exile.Process` directly.
+`Exile.stream!` is a convenience wrapper around `Exile.Process`. Prefer using `Exile.stream!` over using `Exile.Process` directly.
 
 Exile requires OTP v22.1 and above.
 
@@ -50,16 +50,16 @@ Internally Exile uses non-blocking asynchronous system calls to interact with th
 **Highlights**
 
 * Back pressure
-* it does not use any middleware program
-  * no additional os process. no performance/resource cost
+* no middleware program
+  * no additional os process. No performance/resource cost
   * no need to install any external command
-* tries to handle zombie process by attempting to cleanup external process. *But* as there is no middleware involved with exile so it is still possbile to endup with zombie process
+* tries to handle zombie process by attempting to clean up external process. *But* as there is no middleware involved with exile, so it is still possible to endup with zombie process if program misbehave.
 * stream abstraction
-* selectively consume stdout and stderr
+* selectively consume stdout and stderr streams
 
 If you are running executing huge number of external programs **concurrently** (more than few hundred) you might have to increase open file descriptors limit (`ulimit -n`)
 
-Non-blocking io can be used for other interesting things. Such as reading named pipe (FIFO) files. `Exile.stream!(~w(cat data.pipe))` does not block schedulers so you can open hundreds of fifo files unlike default `file` based io.
+Non-blocking io can be used for other interesting things. Such as reading named pipe (FIFO) files. `Exile.stream!(~w(cat data.pipe))` does not block schedulers, so you can open hundreds of fifo files unlike default `file` based io.
 
 #### TODO
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Internally Exile uses non-blocking asynchronous system calls to interact with th
   * no need to install any external command
 * tries to handle zombie process by attempting to cleanup external process. *But* as there is no middleware involved with exile so it is still possbile to endup with zombie process
 * stream abstraction
+* selectively consume stdout and stderr
 
 If you are running executing huge number of external programs **concurrently** (more than few hundred) you might have to increase open file descriptors limit (`ulimit -n`)
 

--- a/c_src/exile.c
+++ b/c_src/exile.c
@@ -1,7 +1,3 @@
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
-#endif
-
 #include "erl_nif.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -12,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include "utils.h"
 
 #ifdef ERTS_DIRTY_SCHEDULERS
 #define USE_DIRTY_IO ERL_NIF_DIRTY_JOB_IO_BOUND
@@ -19,37 +16,8 @@
 #define USE_DIRTY_IO 0
 #endif
 
-// #define DEBUG
-
-#ifdef DEBUG
-#define debug(...)                                                             \
-  do {                                                                         \
-    enif_fprintf(stderr, "%s:%d\t(fn \"%s\")  - ", __FILE__, __LINE__,         \
-                 __func__);                                                    \
-    enif_fprintf(stderr, __VA_ARGS__);                                         \
-    enif_fprintf(stderr, "\n");                                                \
-  } while (0)
-#else
-#define debug(...)
-#endif
-
-#define error(...)                                                             \
-  do {                                                                         \
-    enif_fprintf(stderr, "%s:%d\t(fn: \"%s\")  - ", __FILE__, __LINE__,        \
-                 __func__);                                                    \
-    enif_fprintf(stderr, __VA_ARGS__);                                         \
-    enif_fprintf(stderr, "\n");                                                \
-  } while (0)
-
-#define assert_argc(argc, count)                                               \
-  if (argc != count) {                                                         \
-    error("number of arguments must be %d", count);                            \
-    return enif_make_badarg(env);                                              \
-  }
-
 static const int UNBUFFERED_READ = -1;
 static const int PIPE_BUF_SIZE = 65535;
-
 static const int FD_CLOSED = -1;
 
 static ERL_NIF_TERM ATOM_TRUE;
@@ -138,7 +106,7 @@ static int select_write(ErlNifEnv *env, int *fd) {
 
 static ERL_NIF_TERM nif_write(ErlNifEnv *env, int argc,
                               const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 2);
+  ASSERT_ARGC(argc, 2);
 
   ErlNifTime start;
   ssize_t size;
@@ -192,7 +160,7 @@ static int select_read(ErlNifEnv *env, int *fd) {
 
 static ERL_NIF_TERM nif_create_fd(ErlNifEnv *env, int argc,
                                   const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 1);
+  ASSERT_ARGC(argc, 1);
 
   ERL_NIF_TERM term;
   ErlNifPid pid;
@@ -224,7 +192,7 @@ static ERL_NIF_TERM nif_create_fd(ErlNifEnv *env, int argc,
 
   return make_ok(env, term);
 
-error_exit:
+ error_exit:
   enif_release_resource(fd);
   return ATOM_ERROR;
 }
@@ -267,7 +235,7 @@ static ERL_NIF_TERM read_fd(ErlNifEnv *env, int *fd, int max_size) {
 
 static ERL_NIF_TERM nif_read(ErlNifEnv *env, int argc,
                              const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 2);
+  ASSERT_ARGC(argc, 2);
 
   int max_size;
   int *fd;
@@ -283,7 +251,7 @@ static ERL_NIF_TERM nif_read(ErlNifEnv *env, int argc,
 
 static ERL_NIF_TERM nif_close(ErlNifEnv *env, int argc,
                               const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 1);
+  ASSERT_ARGC(argc, 1);
 
   int *fd;
 
@@ -300,7 +268,7 @@ static ERL_NIF_TERM nif_close(ErlNifEnv *env, int argc,
 
 static ERL_NIF_TERM nif_is_os_pid_alive(ErlNifEnv *env, int argc,
                                         const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 1);
+  ASSERT_ARGC(argc, 1);
 
   pid_t pid;
 
@@ -317,7 +285,7 @@ static ERL_NIF_TERM nif_is_os_pid_alive(ErlNifEnv *env, int argc,
 
 static ERL_NIF_TERM nif_kill(ErlNifEnv *env, int argc,
                              const ERL_NIF_TERM argv[]) {
-  assert_argc(argc, 2);
+  ASSERT_ARGC(argc, 2);
 
   pid_t pid;
   int ret;

--- a/c_src/spawner.c
+++ b/c_src/spawner.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -62,11 +63,12 @@ static int set_flag(int fd, int flags) {
   return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | flags);
 }
 
-static int send_io_fds(int socket, int read_fd, int write_fd) {
+static int send_io_fds(int socket, int stdin_fd, int stdout_fd, int stderr_fd) {
   struct msghdr msg = {0};
   struct cmsghdr *cmsg;
-  int fds[2];
-  char buf[CMSG_SPACE(2 * sizeof(int))], dup[256];
+  int fds[3];
+  char buf[CMSG_SPACE(3 * sizeof(int))];
+  char dup[256];
   struct iovec io;
 
   memset(buf, '\0', sizeof(buf));
@@ -82,12 +84,15 @@ static int send_io_fds(int socket, int read_fd, int write_fd) {
   cmsg = CMSG_FIRSTHDR(&msg);
   cmsg->cmsg_level = SOL_SOCKET;
   cmsg->cmsg_type = SCM_RIGHTS;
-  cmsg->cmsg_len = CMSG_LEN(2 * sizeof(int));
+  cmsg->cmsg_len = CMSG_LEN(3 * sizeof(int));
 
-  fds[0] = read_fd;
-  fds[1] = write_fd;
+  fds[0] = stdin_fd;
+  fds[1] = stdout_fd;
+  fds[2] = stderr_fd;
 
-  memcpy((int *)CMSG_DATA(cmsg), fds, 2 * sizeof(int));
+  debug("stdout: %d, stderr: %d", stdout_fd, stderr_fd);
+
+  memcpy((int *)CMSG_DATA(cmsg), fds, 3 * sizeof(int));
 
   if (sendmsg(socket, &msg, 0) < 0) {
     debug("Failed to send message");
@@ -97,8 +102,8 @@ static int send_io_fds(int socket, int read_fd, int write_fd) {
   return EXIT_SUCCESS;
 }
 
-static void close_pipes(int pipes[2][2]) {
-  for (int i = 0; i < 2; i++) {
+static void close_pipes(int pipes[3][2]) {
+  for (int i = 0; i < 3; i++) {
     if (pipes[i][PIPE_READ] > 0)
       close(pipes[i][PIPE_READ]);
     if (pipes[i][PIPE_WRITE] > 0)
@@ -106,12 +111,14 @@ static void close_pipes(int pipes[2][2]) {
   }
 }
 
-static int exec_process(char const *bin, char *const *args, int socket) {
-  int pipes[2][2] = {{0, 0}, {0, 0}};
-  int r_cmdin, w_cmdin, r_cmdout, w_cmdout;
+static int exec_process(char const *bin, char *const *args, int socket,
+                        bool use_stderr) {
+  int pipes[3][2] = {{0, 0}, {0, 0}, {0, 0}};
+  int r_cmdin, w_cmdin, r_cmdout, w_cmdout, r_cmderr, w_cmderr;
   int i;
 
-  if (pipe(pipes[STDIN_FILENO]) == -1 || pipe(pipes[STDOUT_FILENO]) == -1) {
+  if (pipe(pipes[STDIN_FILENO]) == -1 || pipe(pipes[STDOUT_FILENO]) == -1 ||
+      pipe(pipes[STDERR_FILENO]) == -1) {
     perror("[spawner] failed to create pipes");
     close_pipes(pipes);
     return 1;
@@ -125,9 +132,14 @@ static int exec_process(char const *bin, char *const *args, int socket) {
   r_cmdout = pipes[STDOUT_FILENO][PIPE_READ];
   w_cmdout = pipes[STDOUT_FILENO][PIPE_WRITE];
 
+  r_cmderr = pipes[STDERR_FILENO][PIPE_READ];
+  w_cmderr = pipes[STDERR_FILENO][PIPE_WRITE];
+
   if (set_flag(r_cmdin, O_CLOEXEC) < 0 || set_flag(w_cmdout, O_CLOEXEC) < 0 ||
+      set_flag(w_cmderr, O_CLOEXEC) < 0 ||
       set_flag(w_cmdin, O_CLOEXEC | O_NONBLOCK) < 0 ||
-      set_flag(r_cmdout, O_CLOEXEC | O_NONBLOCK) < 0) {
+      set_flag(r_cmdout, O_CLOEXEC | O_NONBLOCK) < 0 ||
+      set_flag(r_cmderr, O_CLOEXEC | O_NONBLOCK) < 0) {
     perror("[spawner] failed to set flags for pipes");
     close_pipes(pipes);
     return 1;
@@ -135,7 +147,7 @@ static int exec_process(char const *bin, char *const *args, int socket) {
 
   debug("set fd flags to pipes");
 
-  if (send_io_fds(socket, w_cmdin, r_cmdout) != EXIT_SUCCESS) {
+  if (send_io_fds(socket, w_cmdin, r_cmdout, r_cmderr) != EXIT_SUCCESS) {
     perror("[spawner] failed to send fd via socket");
     close_pipes(pipes);
     return 1;
@@ -157,6 +169,18 @@ static int exec_process(char const *bin, char *const *args, int socket) {
     _exit(FORK_EXEC_FAILURE);
   }
 
+  if (use_stderr) {
+    close(STDERR_FILENO);
+    close(r_cmderr);
+    if (dup2(w_cmderr, STDERR_FILENO) < 0) {
+      perror("[spawner] failed to dup to stderr");
+      _exit(FORK_EXEC_FAILURE);
+    }
+  } else {
+    close(r_cmderr);
+    close(w_cmderr);
+  }
+
   /* Close all non-standard io fds. Not closing STDERR */
   for (i = STDERR_FILENO + 1; i < sysconf(_SC_OPEN_MAX); i++)
     close(i);
@@ -169,9 +193,17 @@ static int exec_process(char const *bin, char *const *args, int socket) {
   _exit(FORK_EXEC_FAILURE);
 }
 
-static int spawn(const char *socket_path, const char *bin, char *const *args) {
+static int spawn(const char *socket_path, const char *use_stderr_str,
+                 const char *bin, char *const *args) {
   int socket_fd;
   struct sockaddr_un socket_addr;
+  bool use_stderr;
+
+  if (strcmp(use_stderr_str, "true") == 0) {
+    use_stderr = true;
+  } else {
+    use_stderr = false;
+  }
 
   socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
@@ -194,7 +226,7 @@ static int spawn(const char *socket_path, const char *bin, char *const *args) {
 
   debug("connected to exile");
 
-  if (exec_process(bin, args, socket_fd) != 0)
+  if (exec_process(bin, args, socket_fd, use_stderr) != 0)
     return EXIT_FAILURE;
 
   // we should never reach here
@@ -205,19 +237,19 @@ int main(int argc, const char *argv[]) {
   int status, i;
   const char **exec_argv;
 
-  if (argc < 3) {
-    debug("expected at least 2 arguments, passed %d", argc);
+  if (argc < 4) {
+    debug("expected at least 3 arguments, passed %d", argc);
     status = EXIT_FAILURE;
   } else {
-    exec_argv = malloc((argc - 2 + 1) * sizeof(char *));
+    exec_argv = malloc((argc - 3 + 1) * sizeof(char *));
 
-    for (i = 2; i < argc; i++)
-      exec_argv[i - 2] = argv[i];
+    for (i = 3; i < argc; i++)
+      exec_argv[i - 3] = argv[i];
 
-    exec_argv[i - 2] = NULL;
+    exec_argv[i - 3] = NULL;
 
-    debug("socket path: %s bin: %s", argv[1], argv[2]);
-    status = spawn(argv[1], argv[2], (char *const *)exec_argv);
+    debug("socket path: %s use_stderr: %s bin: %s", argv[1], argv[2], argv[3]);
+    status = spawn(argv[1], argv[2], argv[3], (char *const *)exec_argv);
   }
 
   exit(status);

--- a/c_src/spawner.c
+++ b/c_src/spawner.c
@@ -1,7 +1,3 @@
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
-#endif
-
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/c_src/utils.h
+++ b/c_src/utils.h
@@ -1,0 +1,39 @@
+#ifndef EXILE_UTILS_H
+#define EXILE_UTILS_H
+
+#include "erl_nif.h"
+#include <stdbool.h>
+
+// #define DEBUG
+
+#ifdef DEBUG
+#define debug(...)                                                             \
+  do {                                                                         \
+    enif_fprintf(stderr, "%s:%d\t(fn \"%s\")  - ", __FILE__, __LINE__,         \
+                 __func__);                                                    \
+    enif_fprintf(stderr, __VA_ARGS__);                                         \
+    enif_fprintf(stderr, "\n");                                                \
+  } while (0)
+#define start_timing() ErlNifTime __start = enif_monotonic_time(ERL_NIF_USEC)
+#define elapsed_microseconds() (enif_monotonic_time(ERL_NIF_USEC) - __start)
+#else
+#define debug(...)
+#define start_timing()
+#define elapsed_microseconds() 0
+#endif
+
+#define error(...)                                                             \
+  do {                                                                         \
+    enif_fprintf(stderr, "%s:%d\t(fn: \"%s\")  - ", __FILE__, __LINE__,        \
+                 __func__);                                                    \
+    enif_fprintf(stderr, __VA_ARGS__);                                         \
+    enif_fprintf(stderr, "\n");                                                \
+  } while (0)
+
+#define ASSERT_ARGC(argc, count)                                               \
+  if (argc != count) {                                                         \
+    error("number of arguments must be %d", count);                            \
+    return enif_make_badarg(env);                                              \
+  }
+
+#endif

--- a/lib/exile.ex
+++ b/lib/exile.ex
@@ -53,7 +53,7 @@ defmodule Exile do
     * `use_stderr` - When set to true, stream will contain stderr output along with stdout output. Element of the stream will be of the form `{:stdout, iodata}` or `{:stderr, iodata}` to differentiate different streams. Defaults to false. See example below
 
 
-  All other options are passed to `Exile.Process.start_link/3`
+  All other options are passed to `Exile.Process.start_link/2`
 
   ### Examples
 

--- a/lib/exile/process.ex
+++ b/lib/exile/process.ex
@@ -7,23 +7,42 @@ defmodule Exile.Process do
   ## Comparison with Port
 
     * it is demand driven. User explicitly has to `read` the command output, and the progress of the external command is controlled using OS pipes. Exile never load more output than we can consume, so we should never experience memory issues
-    * it can close stdin while consuming stdout
+    * it can close stdin while consuming output
     * tries to handle zombie process by attempting to cleanup external process. Note that there is no middleware involved with exile so it is still possbile to endup with zombie process.
 
   Internally Exile uses non-blocking asynchronous system calls to interact with the external process. It does not use port's message based communication, instead uses raw stdio and NIF. Uses asynchronous system calls for IO. Most of the system calls are non-blocking, so it should not block the beam schedulers. Make use of dirty-schedulers for IO
   """
 
-  alias Exile.ProcessNif, as: Nif
-  require Logger
   use GenServer
 
-  defmodule Error do
-    defexception [:message]
+  alias __MODULE__
+  alias Exile.ProcessNif, as: Nif
+  require Logger
+
+  defstruct [
+    :args,
+    :errno,
+    :port,
+    :socket_path,
+    :stdin,
+    :stdout,
+    :stderr,
+    :status,
+    :use_stderr,
+    :await,
+    :read_stdout,
+    :read_stderr,
+    :read_any,
+    :write_stdin
+  ]
+
+  defmodule Pending do
+    @moduledoc false
+    defstruct bin: [], size: 0, client_pid: nil
   end
 
-  alias Exile.Process.Error
-
-  @default_opts [env: []]
+  @default_opts [env: [], use_stderr: false]
+  @default_buffer_size 65535
 
   @doc """
   Starts `Exile.ProcessServer`
@@ -35,6 +54,7 @@ defmodule Exile.Process do
   ### Options
     * `cd`   -  the directory to run the command in
     * `env`  -  a list of tuples containing environment key-value. These can be accessed in the external program
+    * `use_stderr`  -  when set to true, exile connects stderr stream for the consumption. Defaults to false. Note that when set to true stderr must be consumed to avoid external program from blocking
   """
   @type process :: pid
   @spec start_link(nonempty_list(String.t()),
@@ -64,22 +84,39 @@ defmodule Exile.Process do
   """
   @spec write(process, binary) :: :ok | {:error, any()}
   def write(process, iodata) do
-    GenServer.call(process, {:write, IO.iodata_to_binary(iodata)}, :infinity)
+    GenServer.call(process, {:write_stdin, IO.iodata_to_binary(iodata)}, :infinity)
   end
 
   @doc """
-  Return bytes written by the program to output stream.
+  Returns bytes from executed command's stdout stream with maximum size `max_size`.
 
-  This blocks until the programs write and flush the output depending on the `size`
+  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are availble
   """
-  @spec read(process, pos_integer()) ::
-          {:ok, iodata} | {:eof, iodata} | {:error, any()}
-  def read(process, size) when (is_integer(size) and size > 0) or size == :unbuffered do
-    GenServer.call(process, {:read, size}, :infinity)
+  @spec read(process, pos_integer()) :: {:ok, iodata} | :eof | {:error, any()}
+  def read(process, max_size \\ @default_buffer_size)
+      when is_integer(max_size) and max_size > 0 do
+    GenServer.call(process, {:read_stdout, max_size}, :infinity)
   end
 
-  def read(process) do
-    GenServer.call(process, {:read, :unbuffered}, :infinity)
+  @doc """
+  Returns bytes from executed command's stderr stream with maximum size `max_size`.
+
+  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are availble
+  """
+  @spec read_stderr(process, pos_integer()) :: {:ok, iodata} | :eof | {:error, any()}
+  def read_stderr(process, size \\ @default_buffer_size) when is_integer(size) and size > 0 do
+    GenServer.call(process, {:read_stderr, size}, :infinity)
+  end
+
+  @doc """
+  Returns bytes from either stdout or stderr stream with maximum size `max_size` whichever is availble.
+
+  Blocks if no bytes are written to stdout/stderr stream yet. And returns as soon as bytes are availble
+  """
+  @spec read_any(process, pos_integer()) ::
+          {:ok, {:stdout, iodata}} | {:ok, {:stderr, iodata}} | :eof | {:error, any()}
+  def read_any(process, size \\ @default_buffer_size) when is_integer(size) and size > 0 do
+    GenServer.call(process, {:read_any, size}, :infinity)
   end
 
   @doc """
@@ -116,35 +153,19 @@ defmodule Exile.Process do
 
   ## Server
 
-  defmodule Pending do
-    @moduledoc false
-    defstruct bin: [], remaining: 0, client_pid: nil
-  end
-
-  defstruct [
-    :args,
-    :errno,
-    :port,
-    :socket_path,
-    :stdin,
-    :stdout,
-    :context,
-    :status,
-    await: %{},
-    pending_read: nil,
-    pending_write: nil
-  ]
-
-  alias __MODULE__
-
   def init(args) do
+    {use_stderr, args} = Map.pop(args, :use_stderr)
+
     state = %__MODULE__{
       args: args,
       errno: nil,
       status: :init,
       await: %{},
-      pending_read: %Pending{},
-      pending_write: %Pending{}
+      use_stderr: use_stderr,
+      read_stdout: %Pending{},
+      read_stderr: %Pending{},
+      read_any: %Pending{},
+      write_stdin: %Pending{}
     }
 
     {:ok, state, {:continue, nil}}
@@ -159,8 +180,11 @@ defmodule Exile.Process do
     # TODO: pending write and read should receive "stopped" return
     # value instead of exit signal
     case state.status do
-      {:exit, _} -> :ok
-      _ -> Port.close(state.port)
+      {:exit, _} ->
+        :ok
+
+      _ ->
+        Port.close(state.port)
     end
 
     {:stop, :normal, :ok, state}
@@ -188,12 +212,39 @@ defmodule Exile.Process do
     {:noreply, %Process{state | await: Map.put(state.await, from, tref)}}
   end
 
-  def handle_call({:read, size}, from, state) do
-    if state.pending_read.client_pid do
-      {:reply, {:error, :pending_read}, state}
-    else
-      pending = %Pending{remaining: size, client_pid: from}
-      do_read(%Process{state | pending_read: pending})
+  def handle_call({:read_stdout, size}, from, state) do
+    case can_read?(state, :stdout) do
+      :ok ->
+        pending = %Pending{size: size, client_pid: from}
+        do_read_stdout(%Process{state | read_stdout: pending})
+
+      error ->
+        GenServer.reply(from, error)
+        {:noreply, state}
+    end
+  end
+
+  def handle_call({:read_stderr, size}, from, state) do
+    case can_read?(state, :stderr) do
+      :ok ->
+        pending = %Pending{size: size, client_pid: from}
+        do_read_stderr(%Process{state | read_stderr: pending})
+
+      error ->
+        GenServer.reply(from, error)
+        {:noreply, state}
+    end
+  end
+
+  def handle_call({:read_any, size}, from, state) do
+    case can_read?(state, :any) do
+      :ok ->
+        pending = %Pending{size: size, client_pid: from}
+        do_read_any(%Process{state | read_any: pending})
+
+      error ->
+        GenServer.reply(from, error)
+        {:noreply, state}
     end
   end
 
@@ -201,17 +252,17 @@ defmodule Exile.Process do
     {:reply, {:error, {:exit, status}}, state}
   end
 
-  def handle_call({:write, binary}, from, state) do
+  def handle_call({:write_stdin, binary}, from, state) do
     cond do
       !is_binary(binary) ->
         {:reply, {:error, :not_binary}, state}
 
-      state.pending_write.client_pid ->
-        {:reply, {:error, :pending_write}, state}
+      state.write_stdin.client_pid ->
+        {:reply, {:error, :write_stdin}, state}
 
       true ->
         pending = %Pending{bin: binary, client_pid: from}
-        do_write(%Process{state | pending_write: pending})
+        do_write(%Process{state | write_stdin: pending})
     end
   end
 
@@ -237,7 +288,27 @@ defmodule Exile.Process do
 
   def handle_info({:select, _write_resource, _ref, :ready_output}, state), do: do_write(state)
 
-  def handle_info({:select, _read_resource, _ref, :ready_input}, state), do: do_read(state)
+  def handle_info({:select, read_resource, _ref, :ready_input}, state) do
+    cond do
+      state.read_any.client_pid ->
+        stream =
+          cond do
+            read_resource == state.stdout -> :stdout
+            read_resource == state.stderr -> :stderr
+          end
+
+        do_read_any(state, stream)
+
+      state.read_stdout.client_pid && read_resource == state.stdout ->
+        do_read_stdout(state)
+
+      state.read_stderr.client_pid && read_resource == state.stderr ->
+        do_read_stderr(state)
+
+      true ->
+        {:noreply, state}
+    end
+  end
 
   def handle_info({port, {:exit_status, exit_status}}, %{port: port} = state),
     do: handle_port_exit(exit_status, state)
@@ -258,110 +329,267 @@ defmodule Exile.Process do
     {:noreply, %Process{state | status: {:exit, exit_status}}, await: %{}}
   end
 
-  defp do_write(%Process{pending_write: %Pending{bin: <<>>}} = state) do
-    GenServer.reply(state.pending_write.client_pid, :ok)
-    {:noreply, %{state | pending_write: %Pending{}}}
+  defmacrop eof, do: {:ok, <<>>}
+  defmacrop eagain, do: {:error, :eagain}
+
+  defp do_write(%Process{write_stdin: %Pending{bin: <<>>}} = state) do
+    reply_action(state, :write_stdin, :ok)
   end
 
-  defp do_write(%Process{pending_write: pending} = state) do
+  defp do_write(%Process{write_stdin: pending} = state) do
+    bin_size = byte_size(pending.bin)
+
     case Nif.nif_write(state.stdin, pending.bin) do
-      {:ok, size} ->
-        if size < byte_size(pending.bin) do
-          binary = binary_part(pending.bin, size, byte_size(pending.bin) - size)
-          {:noreply, %{state | pending_write: %Pending{pending | bin: binary}}}
-        else
-          GenServer.reply(pending.client_pid, :ok)
-          {:noreply, %{state | pending_write: %Pending{}}}
-        end
+      {:ok, size} when size < bin_size ->
+        binary = binary_part(pending.bin, size, bin_size - size)
+        noreply_action(%{state | write_stdin: %Pending{pending | bin: binary}})
 
-      {:error, :eagain} ->
-        {:noreply, state}
+      {:ok, _size} ->
+        reply_action(state, :write_stdin, :ok)
+
+      eagain() ->
+        noreply_action(state)
 
       {:error, errno} ->
-        GenServer.reply(pending.client_pid, {:error, errno})
-        {:noreply, %{state | errno: errno}}
+        reply_action(%Process{state | errno: errno}, :write_stdin, {:error, errno})
     end
   end
 
-  defp do_read(%Process{pending_read: %Pending{remaining: :unbuffered} = pending} = state) do
-    case Nif.nif_read(state.stdout, -1) do
-      {:ok, <<>>} ->
-        GenServer.reply(pending.client_pid, {:eof, []})
-        {:noreply, %Process{state | pending_read: %Pending{}}}
+  defp do_read_stdout(%Process{read_stdout: pending} = state) do
+    case Nif.nif_read(state.stdout, pending.size) do
+      eof() ->
+        reply_action(state, :read_stdout, :eof)
 
       {:ok, binary} ->
-        GenServer.reply(pending.client_pid, {:ok, binary})
-        {:noreply, %Process{state | pending_read: %Pending{}}}
+        reply_action(state, :read_stdout, {:ok, binary})
 
-      {:error, :eagain} ->
-        {:noreply, state}
+      eagain() ->
+        noreply_action(state)
 
       {:error, errno} ->
-        GenServer.reply(pending.client_pid, {:error, errno})
-        {:noreply, %Process{state | pending_read: %Pending{}, errno: errno}}
+        reply_action(%Process{state | errno: errno}, :read_stdout, {:error, errno})
     end
   end
 
-  defp do_read(%Process{pending_read: pending} = state) do
-    case Nif.nif_read(state.stdout, pending.remaining) do
-      {:ok, <<>>} ->
-        GenServer.reply(pending.client_pid, {:eof, pending.bin})
-        {:noreply, %Process{state | pending_read: %Pending{}}}
+  defp do_read_stderr(%Process{read_stderr: pending} = state) do
+    case Nif.nif_read(state.stderr, pending.size) do
+      eof() ->
+        reply_action(state, :read_stderr, :eof)
 
       {:ok, binary} ->
-        if byte_size(binary) < pending.remaining do
-          pending = %Pending{
-            pending
-            | bin: [pending.bin | binary],
-              remaining: pending.remaining - byte_size(binary)
-          }
+        reply_action(state, :read_stderr, {:ok, binary})
 
-          {:noreply, %Process{state | pending_read: pending}}
-        else
-          GenServer.reply(pending.client_pid, {:ok, [state.pending_read.bin | binary]})
-          {:noreply, %Process{state | pending_read: %Pending{}}}
-        end
-
-      {:error, :eagain} ->
-        {:noreply, state}
+      eagain() ->
+        noreply_action(state)
 
       {:error, errno} ->
-        GenServer.reply(pending.client_pid, {:error, errno})
-        {:noreply, %{state | pending_read: %Pending{}, errno: errno}}
+        reply_action(%Process{state | errno: errno}, :read_stderr, {:error, errno})
     end
   end
 
-  defp do_close(state, type) do
-    fd =
-      if type == :stdin do
-        state.stdin
-      else
-        state.stdout
+  defp do_read_any(state, stream_hint \\ :stdout) do
+    %Process{read_any: pending, use_stderr: use_stderr} = state
+
+    other_stream =
+      case stream_hint do
+        :stdout -> :stderr
+        :stderr -> :stdout
       end
 
-    case Nif.nif_close(fd) do
-      :ok ->
-        {:reply, :ok, state}
+    case Nif.nif_read(stream_fd(state, stream_hint), pending.size) do
+      ret when ret in [eof(), eagain()] and use_stderr == true ->
+        case {ret, Nif.nif_read(stream_fd(state, other_stream), pending.size)} do
+          {eof(), eof()} ->
+            reply_action(state, :read_any, :eof)
+
+          {_, {:ok, binary}} ->
+            reply_action(state, :read_any, {:ok, {other_stream, binary}})
+
+          {_, eagain()} ->
+            noreply_action(state)
+
+          {_, {:error, errno}} ->
+            reply_action(%Process{state | errno: errno}, :read_any, {:error, errno})
+        end
+
+      eof() ->
+        reply_action(state, :read_any, :eof)
+
+      {:ok, binary} ->
+        reply_action(state, :read_any, {:ok, {stream_hint, binary}})
+
+      eagain() ->
+        noreply_action(state)
 
       {:error, errno} ->
-        # FIXME: correct
-        raise errno
-        {:reply, {:error, errno}, %Process{state | errno: errno}}
+        reply_action(%Process{state | errno: errno}, :read_any, {:error, errno})
     end
   end
 
-  defp normalize_cmd([cmd | _]) when is_binary(cmd) do
-    path = System.find_executable(cmd)
+  defp do_close(state, stream) do
+    ret = Nif.nif_close(stream_fd(state, stream))
+    {:reply, ret, state}
+  end
 
-    if path do
-      {:ok, to_charlist(path)}
-    else
-      {:error, "command not found: #{inspect(cmd)}"}
+  defp stream_fd(state, stream) do
+    case stream do
+      :stdin -> state.stdin
+      :stdout -> state.stdout
+      :stderr -> state.stderr
     end
   end
 
-  defp normalize_cmd(_cmd_with_args) do
-    {:error, "`cmd_with_args` must be a list of strings, Please check the documentation"}
+  defp can_read?(state, :stdout) do
+    cond do
+      state.read_stdout.client_pid ->
+        {:error, :pending_stdout_read}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp can_read?(state, :stderr) do
+    cond do
+      !state.use_stderr ->
+        {:error, :cannot_read_stderr}
+
+      state.read_stderr.client_pid ->
+        {:error, :pending_stderr_read}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp can_read?(state, :any) do
+    with :ok <- can_read?(state, :stdout) do
+      if state.use_stderr do
+        can_read?(state, :stderr)
+      else
+        :ok
+      end
+    end
+  end
+
+  defp signal(port, sig) when sig in [:sigkill, :sigterm] do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> Nif.nif_kill(os_pid, sig)
+      :undefined -> {:error, :process_not_alive}
+    end
+  end
+
+  @spawner_path :filename.join(:code.priv_dir(:exile), "spawner")
+
+  defp start_process(state) do
+    %{args: %{cmd_with_args: cmd_with_args, cd: cd, env: env}, use_stderr: use_stderr} = state
+
+    socket_path = socket_path()
+    {:ok, sock} = :socket.open(:local, :stream, :default)
+
+    try do
+      :ok = socket_bind(sock, socket_path)
+      :ok = :socket.listen(sock)
+
+      spawner_cmdline_args = [socket_path, to_string(use_stderr) | cmd_with_args]
+
+      port_opts =
+        [:nouse_stdio, :exit_status, :binary, args: spawner_cmdline_args] ++
+          prune_nils(env: env, cd: cd)
+
+      port = Port.open({:spawn_executable, @spawner_path}, port_opts)
+
+      {:os_pid, os_pid} = Port.info(port, :os_pid)
+      Exile.Watcher.watch(self(), os_pid, socket_path)
+
+      {stdin, stdout, stderr} = receive_fds(sock, state.use_stderr)
+
+      %Process{
+        state
+        | port: port,
+          status: :start,
+          socket_path: socket_path,
+          stdin: stdin,
+          stdout: stdout,
+          stderr: stderr
+      }
+    after
+      :socket.close(sock)
+    end
+  end
+
+  @socket_timeout 2000
+
+  defp receive_fds(lsock, use_stderr) do
+    {:ok, sock} = :socket.accept(lsock, @socket_timeout)
+
+    try do
+      {:ok, msg} = :socket.recvmsg(sock, @socket_timeout)
+      %{ctrl: [%{data: data, level: :socket, type: :rights}]} = msg
+
+      <<stdin_fd::native-32, stdout_fd::native-32, stderr_fd::native-32, _::binary>> = data
+
+      {:ok, stdout} = Nif.nif_create_fd(stdout_fd)
+      {:ok, stdin} = Nif.nif_create_fd(stdin_fd)
+
+      {:ok, stderr} =
+        if use_stderr do
+          Nif.nif_create_fd(stderr_fd)
+        else
+          {:ok, nil}
+        end
+
+      {stdin, stdout, stderr}
+    after
+      :socket.close(sock)
+    end
+  end
+
+  defp socket_bind(sock, path) do
+    case :socket.bind(sock, %{family: :local, path: path}) do
+      :ok -> :ok
+      # for OTP version <= 24 compatibility
+      {:ok, _} -> :ok
+      other -> other
+    end
+  end
+
+  defp socket_path do
+    str = :crypto.strong_rand_bytes(16) |> Base.url_encode64() |> binary_part(0, 16)
+    path = Path.join(System.tmp_dir!(), str)
+    _ = :file.delete(path)
+    path
+  end
+
+  defp prune_nils(kv) do
+    Enum.reject(kv, fn {_, v} -> is_nil(v) end)
+  end
+
+  defp reply_action(state, action, return_value) do
+    pending = Map.fetch!(state, action)
+
+    :ok = GenServer.reply(pending.client_pid, return_value)
+    {:noreply, Map.put(state, action, %Pending{})}
+  end
+
+  defp noreply_action(state) do
+    {:noreply, state}
+  end
+
+  defp normalize_cmd(arg) do
+    case arg do
+      [cmd | _] when is_binary(cmd) ->
+        path = System.find_executable(cmd)
+
+        if path do
+          {:ok, to_charlist(path)}
+        else
+          {:error, "command not found: #{inspect(cmd)}"}
+        end
+
+      _ ->
+        {:error, "`cmd_with_args` must be a list of strings, Please check the documentation"}
+    end
   end
 
   defp normalize_cmd_args([_ | args]) do
@@ -372,29 +600,56 @@ defmodule Exile.Process do
     end
   end
 
-  defp normalize_cd(nil), do: {:ok, ''}
-
   defp normalize_cd(cd) do
-    if File.exists?(cd) && File.dir?(cd) do
-      {:ok, to_charlist(cd)}
-    else
-      {:error, "`:cd` must be valid directory path"}
+    case cd do
+      nil ->
+        {:ok, ''}
+
+      cd when is_binary(cd) ->
+        if File.exists?(cd) && File.dir?(cd) do
+          {:ok, to_charlist(cd)}
+        else
+          {:error, "`:cd` must be valid directory path"}
+        end
+
+      _ ->
+        {:error, "`:cd` must be a binary string"}
     end
   end
 
-  defp normalize_env(nil), do: {:ok, []}
-
   defp normalize_env(env) do
-    env =
-      Enum.map(env, fn {key, value} ->
-        {to_charlist(key), to_charlist(value)}
-      end)
+    case env do
+      nil ->
+        {:ok, []}
 
-    {:ok, env}
+      env when is_list(env) or is_map(env) ->
+        env =
+          Enum.map(env, fn {key, value} ->
+            {to_charlist(key), to_charlist(value)}
+          end)
+
+        {:ok, env}
+
+      _ ->
+        {:error, "`:env` must be a map or list of `{string, string}`"}
+    end
+  end
+
+  defp normalize_use_stderr(use_stderr) do
+    case use_stderr do
+      nil ->
+        {:ok, false}
+
+      use_stderr when is_boolean(use_stderr) ->
+        {:ok, use_stderr}
+
+      _ ->
+        {:error, ":use_stderr must be a boolean"}
+    end
   end
 
   defp validate_opts_fields(opts) do
-    {_, additional_opts} = Keyword.split(opts, [:cd, :env])
+    {_, additional_opts} = Keyword.split(opts, [:cd, :env, :use_stderr])
 
     if Enum.empty?(additional_opts) do
       :ok
@@ -408,112 +663,9 @@ defmodule Exile.Process do
          {:ok, args} <- normalize_cmd_args(cmd_with_args),
          :ok <- validate_opts_fields(opts),
          {:ok, cd} <- normalize_cd(opts[:cd]),
+         {:ok, use_stderr} <- normalize_use_stderr(opts[:use_stderr]),
          {:ok, env} <- normalize_env(opts[:env]) do
-      {:ok, %{cmd_with_args: [cmd | args], cd: cd, env: env}}
-    end
-  end
-
-  @spawner_path :filename.join(:code.priv_dir(:exile), "spawner")
-
-  defp exec(cmd_with_args, socket_path, env, cd) do
-    opts = []
-    opts = if cd, do: [{:cd, cd} | opts], else: []
-    opts = if env, do: [{:env, env} | opts], else: opts
-
-    opts =
-      [
-        :nouse_stdio,
-        :exit_status,
-        :binary,
-        args: [socket_path | cmd_with_args]
-      ] ++ opts
-
-    Port.open({:spawn_executable, @spawner_path}, opts)
-  end
-
-  defp socket_path do
-    str = :crypto.strong_rand_bytes(16) |> Base.url_encode64() |> binary_part(0, 16)
-    path = Path.join(System.tmp_dir!(), str)
-    _ = :file.delete(path)
-    path
-  end
-
-  defp signal(port, sig) when sig in [:sigkill, :sigterm] do
-    case Port.info(port, :os_pid) do
-      {:os_pid, os_pid} -> Nif.nif_kill(os_pid, sig)
-      :undefined -> {:error, :process_not_alive}
-    end
-  end
-
-  defp start_process(%{args: %{cmd_with_args: cmd_with_args, cd: cd, env: env}} = state) do
-    path = socket_path()
-    {:ok, sock} = :socket.open(:local, :stream, :default)
-
-    try do
-      :ok = socket_bind(sock, path)
-      :ok = :socket.listen(sock)
-
-      port = exec(cmd_with_args, path, env, cd)
-      {:os_pid, os_pid} = Port.info(port, :os_pid)
-      Exile.Watcher.watch(self(), os_pid, path)
-
-      {stdout, stdin} = receive_fds(sock)
-
-      %Process{
-        state
-        | port: port,
-          status: :start,
-          socket_path: path,
-          stdin: stdin,
-          stdout: stdout
-      }
-    after
-      :socket.close(sock)
-    end
-  end
-
-  @socket_timeout 2000
-  defp receive_fds(lsock) do
-    {:ok, sock} = :socket.accept(lsock, @socket_timeout)
-
-    try do
-      case :socket.recvmsg(sock, @socket_timeout) do
-        {:ok, msg} ->
-          %{
-            ctrl: [
-              %{
-                data: <<stdin_fd_int::native-32, stdout_fd_int::native-32, _::binary>>,
-                level: :socket,
-                type: :rights
-              }
-            ]
-          } = msg
-
-          with {:ok, stdout} <- Nif.nif_create_fd(stdout_fd_int),
-               {:ok, stdin} <- Nif.nif_create_fd(stdin_fd_int) do
-            {stdout, stdin}
-          else
-            error ->
-              raise Error,
-                message: "Failed to create fd resources\n  error: #{inspect(error)}"
-          end
-
-        {:error, reason} ->
-          raise Error,
-            message:
-              "Failed to receive stdin and stdout file descriptors\n  error: #{inspect(reason)}"
-      end
-    after
-      :socket.close(sock)
-    end
-  end
-
-  defp socket_bind(sock, path) do
-    case :socket.bind(sock, %{family: :local, path: path}) do
-      :ok -> :ok
-      # for OTP version <= 24 compatibility
-      {:ok, _} -> :ok
-      other -> other
+      {:ok, %{cmd_with_args: [cmd | args], cd: cd, env: env, use_stderr: use_stderr}}
     end
   end
 end

--- a/lib/exile/process.ex
+++ b/lib/exile/process.ex
@@ -42,6 +42,10 @@ defmodule Exile.Process do
     defstruct bin: [], size: 0, client_pid: nil
   end
 
+  defmodule Error do
+    defexception [:message]
+  end
+
   @default_opts [env: [], use_stderr: false]
   @default_buffer_size 65535
 

--- a/lib/exile/process_nif.ex
+++ b/lib/exile/process_nif.ex
@@ -11,7 +11,7 @@ defmodule Exile.ProcessNif do
 
   def nif_kill(_os_pid, _signal), do: :erlang.nif_error(:nif_library_not_loaded)
 
-  def nif_read(_fd, _request), do: :erlang.nif_error(:nif_library_not_loaded)
+  def nif_read(_fd, _max_size), do: :erlang.nif_error(:nif_library_not_loaded)
 
   def nif_create_fd(_fd), do: :erlang.nif_error(:nif_library_not_loaded)
 

--- a/lib/exile/stream.ex
+++ b/lib/exile/stream.ex
@@ -1,12 +1,14 @@
 defmodule Exile.Stream do
   @moduledoc """
-  Defines a `Exile.Stream` struct returned by `Exile.stream!/3`.
+  Defines a `Exile.Stream` struct returned by `Exile.stream!/2`.
   """
 
   alias Exile.Process
   alias Exile.Process.Error
 
   defmodule Sink do
+    @moduledoc false
+
     defstruct [:process]
 
     defimpl Collectable do

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Exile.MixProject do
   def application do
     [
       mod: {Exile, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 

--- a/test/exile_test.exs
+++ b/test/exile_test.exs
@@ -2,22 +2,61 @@ defmodule ExileTest do
   use ExUnit.Case
 
   test "stream with enumerable" do
-    proc_stream = Exile.stream!(["cat"], input: Stream.map(1..1000, fn _ -> "a" end))
-    output = proc_stream |> Enum.to_list()
-    assert IO.iodata_length(output) == 1000
+    proc_stream =
+      Exile.stream!(["cat"], input: Stream.map(1..1000, fn _ -> "a" end), use_stderr: false)
+
+    stdout = Enum.to_list(proc_stream)
+    assert IO.iodata_length(stdout) == 1000
   end
 
   test "stream with collectable" do
     proc_stream =
       Exile.stream!(["cat"], input: fn sink -> Enum.into(1..1000, sink, fn _ -> "a" end) end)
 
-    output = proc_stream |> Enum.to_list()
-    assert IO.iodata_length(output) == 1000
+    stdout = Enum.to_list(proc_stream)
+    assert IO.iodata_length(stdout) == 1000
   end
 
   test "stream without stdin" do
     proc_stream = Exile.stream!(~w(echo hello))
-    output = proc_stream |> Enum.to_list()
-    assert IO.iodata_to_binary(output) == "hello\n"
+    stdout = Enum.to_list(proc_stream)
+    assert IO.iodata_to_binary(stdout) == "hello\n"
+  end
+
+  test "stderr" do
+    proc_stream = Exile.stream!(["sh", "-c", "echo foo >>/dev/stderr"], use_stderr: true)
+
+    assert {[], stderr} = split_stream(proc_stream)
+    assert IO.iodata_to_binary(stderr) == "foo\n"
+  end
+
+  test "multiple streams" do
+    script = """
+    for i in {1..1000}; do
+      echo "foo ${i}"
+      echo "bar ${i}" >&2
+    done
+    """
+
+    proc_stream = Exile.stream!(["sh", "-c", script], use_stderr: true)
+
+    {stdout, stderr} = split_stream(proc_stream)
+
+    stdout_lines = String.split(Enum.join(stdout), "\n", trim: true)
+    stderr_lines = String.split(Enum.join(stderr), "\n", trim: true)
+
+    assert length(stdout_lines) == length(stderr_lines)
+    assert Enum.all?(stdout_lines, &String.starts_with?(&1, "foo "))
+    assert Enum.all?(stderr_lines, &String.starts_with?(&1, "bar "))
+  end
+
+  defp split_stream(stream) do
+    {stdout, stderr} =
+      Enum.reduce(stream, {[], []}, fn
+        {:stdout, data}, {stdout, stderr} -> {[data | stdout], stderr}
+        {:stderr, data}, {stdout, stderr} -> {stdout, [data | stderr]}
+      end)
+
+    {Enum.reverse(stdout), Enum.reverse(stderr)}
   end
 end


### PR DESCRIPTION
### Breaking changes

* `Process.read` behavior is changed. Previously `Process.read(process, 100)` returned exactly 100 bytes (or `eof`) but now it returns *at max* `100` bytes. It can be of any size between 0 and 100 bytes.