### PR TITLE
Correct process exit handling

### DIFF
--- a/lib/exile/process.ex
+++ b/lib/exile/process.ex
@@ -185,14 +185,6 @@ defmodule Exile.Process do
   def handle_call(:stop, _from, state) do
     # TODO: pending write and read should receive "stopped" return
     # value instead of exit signal
-    case state.status do
-      {:exit, _} ->
-        :ok
-
-      _ ->
-        Port.close(state.port)
-    end
-
     {:stop, :normal, :ok, state}
   end
 

--- a/test/exile/process_test.exs
+++ b/test/exile/process_test.exs
@@ -132,7 +132,7 @@ defmodule Exile.ProcessTest do
     Process.stop(s)
   end
 
-  test "stderr_any" do
+  test "read_any" do
     script = """
     echo "foo"
     echo "bar" >&2
@@ -149,7 +149,7 @@ defmodule Exile.ProcessTest do
     Process.stop(s)
   end
 
-  test "stderr_any with stderr disabled" do
+  test "read_any with stderr disabled" do
     script = """
     echo "foo"
     echo "bar" >&2


### PR DESCRIPTION
No need to close port explicitly while exiting. Beam will close the port on exit