### PR TITLE
Fix typos

### DIFF
--- a/lib/exile.ex
+++ b/lib/exile.ex
@@ -48,7 +48,7 @@ defmodule Exile do
 
     * `exit_timeout` - Duration to wait for external program to exit after completion before raising an error. Defaults to `:infinity`
 
-    * `max_chunk_size` - Maximum size of each iodata chunk emitted by stream. Chunk size will be variable depending on the amount of data availble at that time. Defaults to 65535
+    * `max_chunk_size` - Maximum size of each iodata chunk emitted by stream. Chunk size will be variable depending on the amount of data available at that time. Defaults to 65535
 
     * `use_stderr` - When set to true, stream will contain stderr output along with stdout output. Element of the stream will be of the form `{:stdout, iodata}` or `{:stderr, iodata}` to differentiate different streams. Defaults to false. See example below
 

--- a/lib/exile/process.ex
+++ b/lib/exile/process.ex
@@ -8,7 +8,7 @@ defmodule Exile.Process do
 
     * it is demand driven. User explicitly has to `read` the command output, and the progress of the external command is controlled using OS pipes. Exile never load more output than we can consume, so we should never experience memory issues
     * it can close stdin while consuming output
-    * tries to handle zombie process by attempting to cleanup external process. Note that there is no middleware involved with exile so it is still possbile to endup with zombie process.
+    * tries to handle zombie process by attempting to cleanup external process. Note that there is no middleware involved with exile so it is still possible to endup with zombie process.
     * selectively consume stdout and stderr streams
 
   Internally Exile uses non-blocking asynchronous system calls to interact with the external process. It does not use port's message based communication, instead uses raw stdio and NIF. Uses asynchronous system calls for IO. Most of the system calls are non-blocking, so it should not block the beam schedulers. Make use of dirty-schedulers for IO
@@ -96,7 +96,7 @@ defmodule Exile.Process do
   @doc """
   Returns bytes from executed command's stdout stream with maximum size `max_size`.
 
-  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are availble
+  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are available
   """
   @spec read(process, pos_integer()) :: {:ok, iodata} | :eof | {:error, any()}
   def read(process, max_size \\ @default_buffer_size)
@@ -107,7 +107,7 @@ defmodule Exile.Process do
   @doc """
   Returns bytes from executed command's stderr stream with maximum size `max_size`.
 
-  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are availble
+  Blocks if no bytes are written to stdout stream yet. And returns as soon as bytes are available
   """
   @spec read_stderr(process, pos_integer()) :: {:ok, iodata} | :eof | {:error, any()}
   def read_stderr(process, size \\ @default_buffer_size) when is_integer(size) and size > 0 do
@@ -115,9 +115,9 @@ defmodule Exile.Process do
   end
 
   @doc """
-  Returns bytes from either stdout or stderr stream with maximum size `max_size` whichever is availble.
+  Returns bytes from either stdout or stderr stream with maximum size `max_size` whichever is available.
 
-  Blocks if no bytes are written to stdout/stderr stream yet. And returns as soon as bytes are availble
+  Blocks if no bytes are written to stdout/stderr stream yet. And returns as soon as bytes are available
   """
   @spec read_any(process, pos_integer()) ::
           {:ok, {:stdout, iodata}} | {:ok, {:stderr, iodata}} | :eof | {:error, any()}

--- a/lib/exile/stream.ex
+++ b/lib/exile/stream.ex
@@ -91,7 +91,7 @@ defmodule Exile.Stream do
 
       after_fun = fn exit_type ->
         try do
-          # always close stdin before stoping to give the command chance to exit properly
+          # always close stdin before stopping to give the command chance to exit properly
           Process.close_stdin(process)
           result = Process.await_exit(process, stream_opts.exit_timeout)
 


### PR DESCRIPTION
Found via `codespell -S deps -L warmup`