### PR TITLE
Fix spawner not being found when under a release

### DIFF
--- a/lib/exile/process/exec.ex
+++ b/lib/exile/process/exec.ex
@@ -10,8 +10,6 @@ defmodule Exile.Process.Exec do
           env: [{String.t(), String.t()}]
         }
 
-  @spawner_path :filename.join(:code.priv_dir(:exile), "spawner")
-
   @spec start(args, boolean()) :: %{
           port: port,
           stdin: non_neg_integer(),
@@ -39,7 +37,7 @@ defmodule Exile.Process.Exec do
         [:nouse_stdio, :exit_status, :binary, args: spawner_cmdline_args] ++
           prune_nils(env: env, cd: cd)
 
-      port = Port.open({:spawn_executable, @spawner_path}, port_opts)
+      port = Port.open({:spawn_executable, spawner_path()}, port_opts)
 
       {:os_pid, os_pid} = Port.info(port, :os_pid)
       Exile.Watcher.watch(self(), os_pid, socket_path)
@@ -65,6 +63,11 @@ defmodule Exile.Process.Exec do
          {:ok, env} <- normalize_env(opts[:env]) do
       {:ok, %{cmd_with_args: [cmd | args], cd: cd, env: env, enable_stderr: enable_stderr}}
     end
+  end
+
+  @spec spawner_path() :: String.t()
+  defp spawner_path() do
+    :filename.join(:code.priv_dir(:exile), "spawner")
   end
 
   @socket_timeout 2000

--- a/lib/exile/process/exec.ex
+++ b/lib/exile/process/exec.ex
@@ -65,8 +65,8 @@ defmodule Exile.Process.Exec do
     end
   end
 
-  @spec spawner_path() :: String.t()
-  defp spawner_path() do
+  @spec spawner_path :: String.t()
+  defp spawner_path do
     :filename.join(:code.priv_dir(:exile), "spawner")
   end
 


### PR DESCRIPTION
Cool library!

I ran into an issue with `spawner` not being found (`enoent` error) when calling `Exile.Process.start_link/2`.

The spawner path is evaluated at compile time:
https://github.com/akash-akya/exile/blob/51adb421a2584c0beb344272324077b6c8bd2c05/lib/exile/process/exec.ex#L12-L14

And therefore `spawner` fails to launch from a release when the compiled code folders are no longer available (for example, from within a Docker container).

Resolving the path at run time fixed the issue for me.

Info:
* Exile version: 0.2.0
* OTP 25.3, Elixir 1.14.4