### PR TITLE
Fix spawner not building on macOS + Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ calling_from_make:
 
 UNAME := $(shell uname)
 
-CFLAGS ?= -D_POSIX_C_SOURCE=200809L -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2 -fsanitize=undefined
+CFLAGS ?= -D_POSIX_C_SOURCE=200809L -Wall -Werror \
+		  -Wno-unused-parameter -Wno-gnu-null-pointer-arithmetic \
+		  -pedantic -std=c99 -O2 -fsanitize=undefined
 
 ifeq ($(UNAME), Darwin)
 	TARGET_CFLAGS ?= -fPIC -undefined dynamic_lookup -dynamiclib -Wextra

--- a/c_src/spawner.c
+++ b/c_src/spawner.c
@@ -9,7 +9,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-// these definitions are Linux only at the moment
 #ifndef CMSG_LEN
 socklen_t CMSG_LEN(size_t len) {
   return (CMSG_DATA((struct cmsghdr *)NULL) - (unsigned char *)NULL) + len;


### PR DESCRIPTION
Specifically, macOS 13.3.1 + clang 14.0.3. Being Apple silicon might not matter but I can't confirm it.

Work around the following warning-turned-into-error under the definition of `CMSG_LEN`:

>> $ mix test
>> mkdir -p priv
>> cc -D_POSIX_C_SOURCE=200809L -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2 -fsanitize=undefined c_src/spawner.c -o priv/spawner
>> c_src/spawner.c:15:11: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wgnu-null-pointer-arithmetic]
>>   return (CMSG_DATA((struct cmsghdr *)NULL) - (unsigned char *)NULL) + len;
>>           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>> /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/socket.h:655:58: note: expanded from macro 'CMSG_DATA'
>> #define CMSG_DATA(cmsg)         ((unsigned char *)(cmsg) + \
>>                                  ~~~~~~~~~~~~~~~~~~~~~~~ ^
>> 1 error generated.
>> make: *** [priv/spawner] Error 1
>> ** (Mix) Could not compile with "make" (exit status: 2).
>> You need to have gcc and make installed. Try running the
>> commands "gcc --version" and / or "make --version". If these programs
>> are not installed, you will be prompted to install them.

Fix the build by disabling the flag that triggers the warning on (recent versions of?) clang.

Alternatively, a hardcoded pointer value other than NULL (for ex, 0x01) could be used to not trigger the warning, but this felt contrived.

I also tried copying a definition of `CMSG_LEN` based on `CMSG_ALIGN`[*] but `CMSG_ALIGN` was not found and I know little about these headers and API.

[*]: https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html

---

Exile 0.4.0
Elixir 1.14.3
OTP 25.3

gcc -v:
```
% gcc -v
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
```

uname -a:
```
% uname -a
Darwin 22.4.0 Darwin Kernel Version 22.4.0: Mon Mar  6 20:59:58 PST 2023; root:xnu-8796.101.5~3/RELEASE_ARM64_T6020 arm64
```