### PR TITLE
Remove UB sanitizer for linux to fix compilation for Alpine linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ calling_from_make:
 
 UNAME := $(shell uname)
 
-CFLAGS ?= -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2 -fsanitize=undefined
+CFLAGS ?= -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2
 
 ifeq ($(UNAME), Darwin)
+	CFLAGS += -fsanitize=undefined
 	TARGET_CFLAGS ?= -fPIC -undefined dynamic_lookup -dynamiclib -Wextra
 endif
 


### PR DESCRIPTION
Alpine linux does not ship with `-lubsan` by default, which is needed for the compilation with `-fsanitize=undefined` flag.

A proper fix would be to dynamically check if the library exists and enabling the flag.
See: https://github.com/Snaipe/alpine-qemu-execve/blob/alpine-3.10/configure

Fixes: #28 