### PR TITLE
ignore_sigterm.sh: Put date after sleep

### DIFF
--- a/test/scripts/ignore_sigterm.sh
+++ b/test/scripts/ignore_sigterm.sh
@@ -5,6 +5,6 @@ trap -- '' SIGINT SIGTERM SIGTSTP
 echo "ignored signals"
 
 while true; do
-    date +%F_%T
     sleep 1
+    date +%F_%T
 done


### PR DESCRIPTION
At least the only way for test/exile/process_test.exs:225 to work correctly
is to use sleep(1) as date and echo barely take any time to execute.
