### PR TITLE
Makefile: Fix for {Net,Free,Open}BSD and generic $CFLAGS in environ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,19 @@ calling_from_make:
 
 UNAME := $(shell uname)
 
-CFLAGS ?= -Wall -Werror -Wno-unused-parameter -pedantic -std=c99 -O2
+CFLAGS ?= -Wall -Werror -Wextra -Wno-unused-parameter -pedantic -O2 -fPIC
 
 ifeq ($(UNAME), Darwin)
-	TARGET_CFLAGS ?= -fPIC -undefined dynamic_lookup -dynamiclib -Wextra
-endif
-
-ifeq ($(UNAME), Linux)
+	TARGET_CFLAGS ?= -undefined dynamic_lookup -dynamiclib -Wextra
+else ifeq (${UNAME}, NetBSD)
+	# c_src/spawner.c fails to compile on NetBSD and Darwin with -D_POSIX_C_SOURCE=200809L
+	# Should be fixed once NetBSD 10 get released:
+	# http://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=57871
+	TARGET_CFLAGS ?= -shared
+else
+	# -D_POSIX_C_SOURCE=200809L needed on musl
 	CFLAGS += -D_POSIX_C_SOURCE=200809L
-	TARGET_CFLAGS ?= -fPIC -shared
+	TARGET_CFLAGS ?= -shared
 endif
 
 all: priv/exile.so priv/spawner
@@ -19,11 +23,11 @@ all: priv/exile.so priv/spawner
 
 priv/exile.so: c_src/exile.c
 	mkdir -p priv
-	$(CC) -I$(ERL_INTERFACE_INCLUDE_DIR) $(TARGET_CFLAGS) $(CFLAGS) c_src/exile.c -o priv/exile.so
+	$(CC) -std=c99 -I$(ERL_INTERFACE_INCLUDE_DIR) $(TARGET_CFLAGS) $(CFLAGS) c_src/exile.c -o priv/exile.so
 
 priv/spawner: c_src/spawner.c
 	mkdir -p priv
-	$(CC) $(CFLAGS) c_src/spawner.c -o priv/spawner
+	$(CC) -std=c99 $(CFLAGS) c_src/spawner.c -o priv/spawner
 
 clean:
 	@rm -rf priv/exile.so priv/spawner


### PR DESCRIPTION
- `CFLAGS ?=` inherits from the environment, so shouldn't have -std=c99
- In practice everything but Darwin uses `-shared`
- NetBSD has a broken CMSG_DATA macro when -D_POSIX_C_SOURCE=200809L is set
their bug but probably better to make it work for now
