### PR TITLE
tests: allow stderr/sigterm tests to work across platforms

### DIFF
--- a/test/scripts/ignore_sigterm.sh
+++ b/test/scripts/ignore_sigterm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 trap -- '' SIGINT SIGTERM SIGTSTP
 

--- a/test/scripts/write_stderr.sh
+++ b/test/scripts/write_stderr.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "$1" >> /dev/stderr


### PR DESCRIPTION
With this minor change, we get all but 1 test passing on FreeBSD:

```
...
Exile.ProcessTest [test/exile/process_test.exs]
  * test if we are leaking file descriptor (skipped) [L#477]
...

Finished in 12.4 seconds (6.1s async, 6.2s sync)
22 doctests, 45 tests, 0 failures, 1 skipped
```