### PR TITLE
Fix CaseClauseError for non-epipe write errors

### DIFF
--- a/lib/exile/stream.ex
+++ b/lib/exile/stream.ex
@@ -40,6 +40,10 @@ defmodule Exile.Stream do
                 # raise error, we catch this error and return `{:error, :epipe}`
                 raise Error, "epipe"
 
+              {:error, errno} ->
+                # handle other error codes (e.g., EBADF, etc)
+                raise Error, "write error errno: #{inspect(errno)}"
+
               :ok ->
                 :ok
             end


### PR DESCRIPTION
### Summary
Fixes a bug where Exile.stream!/2 crashes with CaseClauseError when the underlying Process.write/2 returns error codes other than :epipe.

### Bug Description
- Error:

```
** (CaseClauseError) no case clause matching: {:error, 9}
    (exile 0.12.0) lib/exile/stream.ex:37: in `anonymous fn/3 in Collectable.Exile.Stream.Sink.into/1`
    (elixir 1.16.0) lib/enum.ex:1555: in `Enum."-reduce_into_protocol/3-lists^foldl/2-0-"/3`
    (elixir 1.16.0) lib/enum.ex:1544: in `Enum.into_protocol/2`
    (exile 0.12.0) lib/exile/stream.ex:196: in `anonymous fn/3 in Enumerable.Exile.Stream.start_input_streamer/2`
```

- Root Cause:

The case statement in the Collectable implementation for Exile.Stream.Sink (line 37) only handled two return values from Process.write/2:
```
{:error, :epipe}
:ok
```
However, Process.write/2 can return {:error, errno} for various POSIX error codes. For example:
```
{:error, 9} = EBADF (Bad file descriptor)
{:error, 32} = EPIPE (Broken pipe, but as integer not atom)
```
And other errno values
When any error other than :epipe occurs, the unmatched return value causes a CaseClauseError.

### Changes
Added a catch-all clause to handle all error codes from Process.write/2:

```
{:error, errno} ->
  # handle other error codes (e.g., EBADF, etc)
  raise Error, "write error errno: #{inspect(errno)}"
```
This ensures all write errors are properly caught and converted to Exile.Process.Error, which is then rescued by the existing error handling at line 198.

This bug occurs in production under race conditions where:

A large input stream is being written to stdin
The external process (ie gpg subprocess) terminates or stdin gets closed unexpectedly
The write operation fails with an errno other than EPIPE
The fix ensures all write errors are handled gracefully rather than crashing with CaseClauseError.